### PR TITLE
Disable search web results in start menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ The names can be used with the -Feature parameter to specify individual settings
 <td>-</td>
 <td>Windows should ask for my feedback</td>
 </tr>
+<tr>
+<td>SearchWebResult</td>
+<td>*</td>
+<td>-</td>
+<td>-</td>
+<td>Let start menu search online and include web results</td>
+</tr>
 
 <tr>
 <td>DoNotTrack</td>

--- a/Set-Privacy.ps1
+++ b/Set-Privacy.ps1
@@ -354,6 +354,10 @@ Begin
         }
     }
 
+    Function SearchWebResult([int]$value){
+        Add-RegistryDWord "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" -Name BingSearchEnabled -value $value
+    }
+
     # ----------- Edge Browser Privacy Functions -----------
 
     [string]$EdgeKey = "HKCU:\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge_8wekyb3d8bbwe\MicrosoftEdge"
@@ -542,6 +546,8 @@ namespace Win32Api
         {
             FeedbackFrequency -value 0
         }
+        # Start Menu
+        SearchWebResult -value $OnOff
 
         # Edge
 


### PR DESCRIPTION
Avoids sending everything you type in the start menu out to Bing.

I set it disabled for both "Balanced" and "Strong" because I don't know anyone who starts a web search in anything other than a web browser, but that's just my personal experience.
