### PR TITLE
Don't use filepath function on registry paths

### DIFF
--- a/Set-Privacy.ps1
+++ b/Set-Privacy.ps1
@@ -153,9 +153,9 @@ Begin
 
         If (!(Test-Path $Path))
         {
-            $parent = [System.IO.Path]::GetDirectoryName($path)
+            $parent = "$path\.."
 
-            $grandParent = [System.IO.Path]::GetDirectoryName($parent)
+            $grandParent = "$parent\.."
             If (!(Test-Path $grandParent))
             {
                 New-item -Path $grandParent | Out-Null


### PR DESCRIPTION
This prevents the following exception I encountered on the Windows 10
Anniversary Update:

```
Exception calling "GetDirectoryName" with "1" argument(s): "The
path is not of a legal form."
```
